### PR TITLE
[fix] motoman_controlの依存関係を修正

### DIFF
--- a/motoman_control/package.xml
+++ b/motoman_control/package.xml
@@ -9,8 +9,6 @@
   <url type="repository">http://github.com/Nishida-Lab/motoman_project</url>
 
   <buildtool_depend>catkin</buildtool_depend>
-  <run_depend>ros_controller</run_depend>
-  <run_depend>ros_control</run_depend>
   <run_depend>controller_manager</run_depend>
 
   


### PR DESCRIPTION
ros_controlとros_controllersを入れると、rosdepできなくなるので、修正
